### PR TITLE
Jot 1691 principle of hiding

### DIFF
--- a/py/builtinhelp.c
+++ b/py/builtinhelp.c
@@ -103,7 +103,21 @@ STATIC void mp_help_print_modules(void) {
     for (unsigned int i = 0; i < num_rows; ++i) {
         unsigned int j = i;
         for (;;) {
-            int l = mp_print_str(MP_PYTHON_PRINTER, mp_obj_str_get_str(items[j]));
+            const char* name = mp_obj_str_get_str(items[j]);
+            
+            #if MICROPY_HIDE_PRIVATE 
+            while ((j < len) && (('_' == name[0]) && ('_' != name[1]))) {
+                j += num_rows;
+                name = mp_obj_str_get_str(items[j]);
+            }
+            
+            if (j >= len) {
+                break;
+            }
+            #endif
+            
+            int l = mp_print_str(MP_PYTHON_PRINTER, name);
+            
             j += num_rows;
             if (j >= len) {
                 break;

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -623,6 +623,11 @@
 #define MICROPY_REPL_EVENT_DRIVEN (0)
 #endif
 
+// Whether to hide modules and members started by _ character or not
+#ifndef MICROPY_HIDE_PRIVATE
+#define MICROPY_HIDE_PRIVATE (0)
+#endif
+
 // Whether to include lexer helper function for unix
 #ifndef MICROPY_HELPER_LEXER_UNIX
 #define MICROPY_HELPER_LEXER_UNIX (0)

--- a/py/repl.c
+++ b/py/repl.c
@@ -197,6 +197,11 @@ size_t mp_repl_autocomplete(const char *str, size_t len, const mp_print_t *print
             for (qstr q = MP_QSTR_ + 1; q < nqstr; ++q) {
                 size_t d_len;
                 const char *d_str = (const char *)qstr_data(q, &d_len);
+                #if MICROPY_HIDE_PRIVATE
+                if (('_' == d_str[0]) && ('_' != d_str[1])) {
+                    continue;
+                }
+                #endif
                 if (s_len <= d_len && strncmp(s_start, d_str, s_len) == 0) {
                     mp_load_method_protected(obj, q, dest, true);
                     if (dest[0] != MP_OBJ_NULL) {
@@ -251,6 +256,11 @@ size_t mp_repl_autocomplete(const char *str, size_t len, const mp_print_t *print
             for (qstr q = q_first; q <= q_last; ++q) {
                 size_t d_len;
                 const char *d_str = (const char *)qstr_data(q, &d_len);
+                #if MICROPY_HIDE_PRIVATE
+                if (('_' == d_str[0]) && ('_' != d_str[1])) {
+                    continue;
+                }
+                #endif
                 if (s_len <= d_len && strncmp(s_start, d_str, s_len) == 0) {
                     mp_load_method_protected(obj, q, dest, true);
                     if (dest[0] != MP_OBJ_NULL) {


### PR DESCRIPTION
Implemented _principle of hiding_ helpers. As in `python` is all the world publicaly accessed, this may confuse beginers brogramers as they can see all members, including those for internal use only. This pullrequest partially solve this issue on the level of `python` `repl` and `help('modules')` command. Following changes was implemented:

1. Command `help('modules')` now show only public modules. This means that any module named `_xyz...` will be hidden (construction used in python to mark up private stuff).
2. repl autocompletation will not offer private members/modules (again members named `_xyz...`)

This does not mean that private members will not be used at all. They still exists and can be used. This only means that only public interface will be provided in form of hint inside `python` console.